### PR TITLE
Add follow-up task list for code review findings

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,21 @@
+# Proposed Follow-up Tasks
+
+## 1. Fix Typographical Error
+- **Location:** `example.py`, manual scraping example output.
+- **Issue:** The message `"🎨 Internal CSS: {len(css_data['internal_css'])} block"` uses the singular word "block" even when multiple blocks are reported.
+- **Proposed Task:** Update the message to use the plural form (e.g., "blocks") or dynamically handle singular/plural wording so the output reads naturally. 【F:example.py†L129-L133】
+
+## 2. Resolve Progress Tracker Bug
+- **Location:** `modules/web_scraper.py` when iterating external CSS, with supporting implementation in `modules/loading_animation.py`.
+- **Issue:** `ProgressTracker.update` is called with two positional arguments (`progress.update(i, description)`), but the method signature only accepts an optional description. The class also lacks the `complete()` method invoked after the loop. This raises runtime exceptions when scraping external CSS or multiple URLs.
+- **Proposed Task:** Align the `ProgressTracker` API and its usage—either update `ProgressTracker` to accept step indexes and provide a `complete()` method, or adjust the callers to match the current interface. 【F:modules/web_scraper.py†L103-L118】【F:modules/loading_animation.py†L173-L217】
+
+## 3. Correct Documentation Instructions
+- **Location:** `README.md` installation section.
+- **Issue:** The README instructs users to run `pip install -r requirements.txt`, but the repository does not contain a `requirements.txt` file, leading to installation errors.
+- **Proposed Task:** Update the documentation to list actual installation steps—either add the missing `requirements.txt` or revise the README to explain dependency installation without referencing a non-existent file. 【F:README.md†L36-L56】
+
+## 4. Improve Test Coverage
+- **Location:** Repository root (no test suite present).
+- **Issue:** The project lacks automated tests to verify core functionality such as filename generation, metadata extraction, or progress tracking.
+- **Proposed Task:** Introduce a `tests/` directory with pytest-based coverage for critical modules—for example, unit tests for `WebScraper.generate_filename` and integration tests using httpbin fixtures to ensure scraping workflows succeed without network regressions. 【5d90c1†L1-L3】


### PR DESCRIPTION
## Summary
- add TASKS.md that captures follow-up work items for typos, bugs, docs, and testing gaps identified during the review

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d8015b53b8832681b6e2dac6add7fe